### PR TITLE
Correctly handle input of hex numbers

### DIFF
--- a/simple-monitor.z80
+++ b/simple-monitor.z80
@@ -88,7 +88,7 @@ process_input_line:
         jr z, input_handler
 
         ;;
-        ;; Unknown command: show a message and restart our monitor
+                ;; Unknown command: show a message and restart our monitor
         ;;
         ;; We just show "ERR" which is simple, and saves bytes compared to
         ;; outputting a longer message and using a print-string routine.
@@ -289,6 +289,15 @@ read_8_bit_ascii_number_uc:
         ld		d, a
 	inc		hl
         ld		a, (hl)
+
+        ;; upper-case the second character too, if necessary.
+        cp 'a'
+        jr c, conty
+        cp 'z'
+        jr nc, conty
+        sub a, 32
+conty:
+
         call		read_8_bit_ascii_number_hex
         or		d
 	inc		hl


### PR DESCRIPTION
Previously if the second character of a two-digit hex number was lower-case it would be assembled incorrectly.  e.g. "0a" would become "2a" for some reason.

This was because we didn't upper-case the second character when processing, only the first.

This closes #2.